### PR TITLE
Fix pull request handling in prepare_shop for modules

### DIFF
--- a/.github/workflows/call-universal_test_workflow.yml
+++ b/.github/workflows/call-universal_test_workflow.yml
@@ -463,8 +463,8 @@ jobs:
               --branch ${{ github.base_ref }} \
               --single-branch 'source/dev-packages/${{ steps.install_module_testplan.outputs.install_module_path }}'
             git -C source fetch origin \
-              refs/pull/${{ github.event_number }}/head:pr_${{ github.event_number }}
-            git -C source checkout pr_${{ github.event_number }}
+              refs/pull/${{ github.event.number }}/head:pr_${{ github.event.number }}
+            git -C source checkout pr_${{ github.event.number }}
           fi
           find . -type f >files.txt
 

--- a/.github/workflows/call-universal_test_workflow.yml
+++ b/.github/workflows/call-universal_test_workflow.yml
@@ -452,7 +452,9 @@ jobs:
         run: |
           AUTH="oxidci:${{ secrets.enterprise_github_token || github.token }}"
 
-          if [[ '${{ github.event_name }}' != 'pull_request' || ( '${{github.repository}}' != 'OXID-eSales/oxideshop_ce' && '${{github.repository}}' != 'OXID-eSales/oxideshop_ee' )]]; then
+          if [[ '${{ github.event_name }}' != 'pull_request' || \
+                ( '${{github.repository}}' != 'OXID-eSales/oxideshop_ce' && \
+                  '${{github.repository}}' != 'OXID-eSales/oxideshop_ee' )]]; then
             git clone --depth 2 \
               https://${AUTH}@github.com/${{ steps.install_module_testplan.outputs.install_module_git_module_url }}.git \
               --branch ${{ steps.install_module_testplan.outputs.install_module_git_module_ref }} \

--- a/.github/workflows/call-universal_test_workflow.yml
+++ b/.github/workflows/call-universal_test_workflow.yml
@@ -452,7 +452,7 @@ jobs:
         run: |
           AUTH="oxidci:${{ secrets.enterprise_github_token || github.token }}"
 
-          if [[ '${{ inputs.github_event_name}}' != 'pull_request' || ( '${{github.repository}}' != 'OXID-eSales/oxideshop_ce' && '${{github.repository}}' != 'OXID-eSales/oxideshop_ee' )]]; then
+          if [[ '${{ github.event_name }}' != 'pull_request' || ( '${{github.repository}}' != 'OXID-eSales/oxideshop_ce' && '${{github.repository}}' != 'OXID-eSales/oxideshop_ee' )]]; then
             git clone --depth 2 \
               https://${AUTH}@github.com/${{ steps.install_module_testplan.outputs.install_module_git_module_url }}.git \
               --branch ${{ steps.install_module_testplan.outputs.install_module_git_module_ref }} \
@@ -460,11 +460,11 @@ jobs:
           else
             git clone --depth 2 \
               https://${AUTH}@github.com/${{ steps.install_module_testplan.outputs.install_module_git_module_url }}.git \
-              --branch ${{ steps.install_module_testplan.outputs.install_module_git_module_ref }} \
+              --branch ${{ github.base_ref }} \
               --single-branch 'source/dev-packages/${{ steps.install_module_testplan.outputs.install_module_path }}'
             git -C source fetch origin \
-              refs/pull/${{ inputs.github_event_number }}/head:pr_${{ inputs.github_event_number }}
-            git -C source checkout pr_${{ inputs.github_event_number }}
+              refs/pull/${{ github.event_number }}/head:pr_${{ github.event_number }}
+            git -C source checkout pr_${{ github.event_number }}
           fi
           find . -type f >files.txt
 

--- a/.github/workflows/call-universal_test_workflow.yml
+++ b/.github/workflows/call-universal_test_workflow.yml
@@ -451,10 +451,21 @@ jobs:
         if: ${{ matrix.testplan != 'skip' }}
         run: |
           AUTH="oxidci:${{ secrets.enterprise_github_token || github.token }}"
-          git clone --depth 2 \
-            https://${AUTH}@github.com/${{ steps.install_module_testplan.outputs.install_module_git_module_url }}.git \
-            --branch ${{ steps.install_module_testplan.outputs.install_module_git_module_ref }} \
-            --single-branch 'source/dev-packages/${{ steps.install_module_testplan.outputs.install_module_path }}'
+
+          if [[ '${{ inputs.github_event_name}}' != 'pull_request' || ( '${{github.repository}}' != 'OXID-eSales/oxideshop_ce' && '${{github.repository}}' != 'OXID-eSales/oxideshop_ee' )]]; then
+            git clone --depth 2 \
+              https://${AUTH}@github.com/${{ steps.install_module_testplan.outputs.install_module_git_module_url }}.git \
+              --branch ${{ steps.install_module_testplan.outputs.install_module_git_module_ref }} \
+              --single-branch 'source/dev-packages/${{ steps.install_module_testplan.outputs.install_module_path }}'
+          else
+            git clone --depth 2 \
+              https://${AUTH}@github.com/${{ steps.install_module_testplan.outputs.install_module_git_module_url }}.git \
+              --branch ${{ steps.install_module_testplan.outputs.install_module_git_module_ref }} \
+              --single-branch 'source/dev-packages/${{ steps.install_module_testplan.outputs.install_module_path }}'
+            git -C source fetch origin \
+              refs/pull/${{ inputs.github_event_number }}/head:pr_${{ inputs.github_event_number }}
+            git -C source checkout pr_${{ inputs.github_event_number }}
+          fi
           find . -type f >files.txt
 
       - name: Install module

--- a/prepare_shop/action.yml
+++ b/prepare_shop/action.yml
@@ -239,14 +239,14 @@ runs:
       run: git clone --depth 1 ${{ inputs.git_sdk_url }} --branch ${{ inputs.git_sdk_ref }} --single-branch .
 
     - name: Clone the shop  (${{ inputs.git_shop_ref }})
-      if: inputs.github_event_name != 'pull_request'
+      if: ${{ inputs.github_event_name != 'pull_request' || ( github.repository != 'OXID-eSales/oxideshop_ce' && github.repository != 'OXID-eSales/oxideshop_ee' ) }}
       shell: bash
       run: |
         git clone --depth 2 ${{ inputs.git_shop_url }} --branch ${{ inputs.git_shop_ref }} --single-branch source
         mkdir source/dev-packages
 
     - name: Clone the shop (PR ${{ inputs.github_event_number }})
-      if: inputs.github_event_name == 'pull_request'
+      if: ${{ inputs.github_event_name == 'pull_request' && ( github.repository == 'OXID-eSales/oxideshop_ce' || github.repository == 'OXID-eSales/oxideshop_ee' ) }}
       shell: bash
       run: |
         git clone --depth 2 ${{ inputs.git_shop_url }} --branch ${{ inputs.github_base_ref }} --single-branch source

--- a/prepare_shop/action.yml
+++ b/prepare_shop/action.yml
@@ -239,6 +239,7 @@ runs:
       run: git clone --depth 1 ${{ inputs.git_sdk_url }} --branch ${{ inputs.git_sdk_ref }} --single-branch .
 
     - name: Clone the shop  (${{ inputs.git_shop_ref }})
+      # yamllint disable-line rule:line-length
       if: ${{ inputs.github_event_name != 'pull_request' || ( github.repository != 'OXID-eSales/oxideshop_ce' && github.repository != 'OXID-eSales/oxideshop_ee' ) }}
       shell: bash
       run: |
@@ -246,6 +247,7 @@ runs:
         mkdir source/dev-packages
 
     - name: Clone the shop (PR ${{ inputs.github_event_number }})
+      # yamllint disable-line rule:line-length
       if: ${{ inputs.github_event_name == 'pull_request' && ( github.repository == 'OXID-eSales/oxideshop_ce' || github.repository == 'OXID-eSales/oxideshop_ee' ) }}
       shell: bash
       run: |


### PR DESCRIPTION
When handling a pull request for a module, we don't want to check out the pull_request branch from the shop in the prepare_shop step. I've adjusted the conditions on the checkout to only do the PR handling if the repo is either oxideshop_ce or oxideshop_ee otherwise, it will check out the base branch for the shop.

I also added pull request handling to the install_module step as we are not using actions/checkout there