### PR TITLE
Output php error log

### DIFF
--- a/.github/workflows/call-universal_test_workflow.yml
+++ b/.github/workflows/call-universal_test_workflow.yml
@@ -373,7 +373,7 @@ jobs:
 
       - name: 'Install shop'
         id: install_shop
-        uses: 'OXID-eSales/github-actions/install_shop@v3'
+        uses: 'OXID-eSales/github-actions/install_shop@v0'
         with:
           container_name: ${{ needs.init.outputs.install_shop_container_name }}
           container_options: ${{ needs.init.outputs.install_shop_container_options }}
@@ -549,7 +549,7 @@ jobs:
       - name: Install module
         if: ${{ matrix.testplan != 'skip' }}
         id: install_module
-        uses: 'OXID-eSales/github-actions/install_module@v3'
+        uses: 'OXID-eSales/github-actions/install_module@v0'
         with:
           container_name: ${{ steps.install_module_testplan.outputs.install_module_container_name }}
           container_options: ${{ steps.install_module_testplan.outputs.install_module_container_options }}
@@ -724,7 +724,7 @@ jobs:
 
       - name: 'Run phpunit tests'
         id: phpunit_run
-        uses: 'OXID-eSales/github-actions/phpunit@v3'
+        uses: 'OXID-eSales/github-actions/phpunit@v0'
         with:
           container_name: ${{ steps.phpunit_testplan.outputs.phpunit_container_name }}
           container_options: ${{ steps.phpunit_testplan.outputs.phpunit_container_options }}
@@ -899,7 +899,7 @@ jobs:
 
       - name: 'Run codeception tests'
         id: codeception_run
-        uses: 'OXID-eSales/github-actions/codeception@v3'
+        uses: 'OXID-eSales/github-actions/codeception@v0'
         with:
           container_name: ${{ steps.codeception_testplan.outputs.codeception_container_name }}
           container_options: '${{ steps.codeception_testplan.outputs.codeception_container_options }} ${{ steps.pre_script.outputs.container_options }}'
@@ -1081,7 +1081,7 @@ jobs:
 
       - name: 'Run tests'
         id: runtest_run
-        uses: 'OXID-eSales/github-actions/runtests@v3'
+        uses: 'OXID-eSales/github-actions/runtests@v0'
         with:
           container_name: ${{ steps.runtest_testplan.outputs.runtest_container_name }}
           container_options: ${{ steps.runtest_testplan.outputs.runtest_container_options }}
@@ -1242,7 +1242,7 @@ jobs:
           docker_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: 'Run phpcs tests'
-        uses: 'OXID-eSales/github-actions/phpcs@v3'
+        uses: 'OXID-eSales/github-actions/phpcs@v0'
         with:
           container_name: ${{ needs.init.outputs.phpcs_tests_container_name }}
           container_options: ${{ needs.init.outputs.phpcs_tests_container_options }}
@@ -1355,7 +1355,7 @@ jobs:
           container_method: 'exec'
 
       - name: 'Run styles check'
-        uses: 'OXID-eSales/github-actions/styles@v3'
+        uses: 'OXID-eSales/github-actions/styles@v0'
         with:
           path: ${{ steps.styles_testplan.outputs.styles_path }}
           module_ids: ${{ steps.styles_testplan.outputs.styles_module_ids }}

--- a/codeception/action.yml
+++ b/codeception/action.yml
@@ -129,7 +129,10 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.output_artifact }}
-        path: ${{ inputs.output_files }}
+        path: |
+          ${{ inputs.logfile }}
+          ${{ inputs.output_files }}
+          ${{ inputs.coverage_path }}
         if-no-files-found: ignore
         retention-days: 7
 
@@ -141,6 +144,16 @@ runs:
         path: ${{ inputs.coverage_path }}
         if-no-files-found: ignore
         retention-days: 7
+
+    - name: Output php error log
+      if: always()
+      shell: bash
+      run: |
+        # codeception: Output php error log
+        if [ -s data/php/logs/error_log.txt ]; then
+          echo -e "\033[0;35mPHP error log\033[0m"
+          cat data/php/logs/error_log.txt
+        fi
 
     - name: Check results
       shell: bash

--- a/install_module/action.yml
+++ b/install_module/action.yml
@@ -199,7 +199,18 @@ runs:
       if: always()
       shell: bash
       run: |
-        find . -type f >files.txt
+        # install_module: Write files list
+        find . >files.txt
+
+    - name: Output php error log
+      if: always()
+      shell: bash
+      run: |
+        # install_module: Output php error log
+        if [ -s data/php/logs/error_log.txt ]; then
+          echo -e "\033[0;35mPHP error log\033[0m"
+          cat data/php/logs/error_log.txt
+        fi
 
     - name: Upload configuration artifacts
       if: always()

--- a/install_shop/action.yml
+++ b/install_shop/action.yml
@@ -67,6 +67,8 @@ inputs:
       source/composer.json
       source/composer.lock
       source/source/config.inc.php
+      data/php/logs/error_log.txt
+      files.txt
   output_artifact:
     type: string
     required: false
@@ -135,11 +137,11 @@ runs:
         # install_shop: Activate iDebug
         perl -pi -e 's#iDebug = 0;#iDebug = -1;#g;' source/source/config.inc.php
 
-    - name: Activate shop's theme
+    - name: Activate theme
       if: ${{ inputs.is_enterprise == 'true' }}
       shell: bash
       run: |
-        # install_shop: Activate shop's theme
+        # install_shop: Activate theme
         docker-compose ${{ inputs.container_method }} -T \
           ${{ inputs.container_options }} \
           ${{ inputs.container_name }} \
@@ -149,7 +151,18 @@ runs:
       if: always()
       shell: bash
       run: |
-        find . -type f >files.txt
+        # install_shop: Write files list
+        find . >files.txt
+
+    - name: Output php error log
+      if: always()
+      shell: bash
+      run: |
+        # install_shop: Output php error log
+        if [ -s data/php/logs/error_log.txt ]; then
+          echo -e "\033[0;35mPHP error log\033[0m"
+          cat data/php/logs/error_log.txt
+        fi
 
     - name: Upload configuration artifacts
       if: always()

--- a/phpcs/action.yml
+++ b/phpcs/action.yml
@@ -112,6 +112,16 @@ runs:
         if-no-files-found: error
         retention-days: 7
 
+    - name: Output php error log
+      if: always()
+      shell: bash
+      run: |
+        # phpcs: Output php error log
+        if [ -s data/php/logs/error_log.txt ]; then
+          echo -e "\033[0;35mPHP error log\033[0m"
+          cat data/php/logs/error_log.txt
+        fi
+
     - name: Check results
       shell: bash
       run: |

--- a/phpcs/action.yml
+++ b/phpcs/action.yml
@@ -59,7 +59,6 @@ runs:
       shell: bash
       run: |
         # phpcs: List changed files
-        set -x
         cd source
         if [ "${{ inputs.diff_only }}" == "true" ]; then
           echo -e "\033[0;35m###  Use git diff for phpcs using filter '${{ inputs.filter }}' ###\033[0m"

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -99,7 +99,10 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.output_artifact }}
-        path: ${{ inputs.output_files }}
+        path: |
+          ${{ inputs.logfile }}
+          ${{ inputs.output_files }}
+          ${{ inputs.coverage_path }}
         if-no-files-found: ignore
         retention-days: 7
 
@@ -112,6 +115,15 @@ runs:
         if-no-files-found: ignore
         retention-days: 7
 
+    - name: Output php error log
+      if: always()
+      shell: bash
+      run: |
+        # phpunit: Output php error log
+        if [ -s data/php/logs/error_log.txt ]; then
+          echo -e "\033[0;35mPHP error log\033[0m"
+          cat data/php/logs/error_log.txt
+        fi
 
     - name: Check results
       shell: bash

--- a/runtests/action.yml
+++ b/runtests/action.yml
@@ -117,7 +117,10 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.output_artifact }}
-        path: ${{ inputs.output_files }}
+        path: |
+          ${{ inputs.logfile }}
+          ${{ inputs.output_files }}
+          ${{ inputs.coverage_path }}
         if-no-files-found: ignore
         retention-days: 7
 
@@ -130,6 +133,15 @@ runs:
         if-no-files-found: ignore
         retention-days: 7
 
+    - name: Output php error log
+      if: always()
+      shell: bash
+      run: |
+        # runtests: Output php error log
+        if [ -s data/php/logs/error_log.txt ]; then
+          echo -e "\033[0;35mPHP error log\033[0m"
+          cat data/php/logs/error_log.txt
+        fi
 
     - name: Check results
       shell: bash

--- a/styles/action.yml
+++ b/styles/action.yml
@@ -40,10 +40,11 @@ inputs:
       source/tests/reports/phpstan*.report.txt
       source/tests/reports/phpmd*.report.txt
       source/tests/reports/phpcs*.report.txt
+      data/php/logs/error_log.txt
   output_artifact:
     type: string
     required: false
-    description: 'Github run artifact for the phpunit output'
+    description: 'Github run artifact for the styles output'
     default: 'StylesLog'
 
 runs:
@@ -129,7 +130,17 @@ runs:
       run: |
         make down
 
-    - name: Upload log artifact
+    - name: Output php error log
+      if: always()
+      shell: bash
+      run: |
+        # styles: Output php error log
+        if [ -s data/php/logs/error_log.txt ]; then
+          echo -e "\033[0;35mPHP error log\033[0m"
+          cat data/php/logs/error_log.txt
+        fi
+
+    - name: Upload artifact
       if: always()
       uses: actions/upload-artifact@v3
       with:

--- a/tests/github_actions/defaults/defaults.yml
+++ b/tests/github_actions/defaults/defaults.yml
@@ -283,6 +283,7 @@ install_shop:
       source/composer.json*
       source/composer.lock
       source/source/config.inc.php
+      data/php/logs/error_log.txt
       files.txt
     # The configuration file name is dynamic, the matrix variables will be appended
     artifact_prefix: 'configs_install_shop'
@@ -699,6 +700,7 @@ styles:
       source/tests/reports/phpstan*.report.txt
       source/tests/reports/phpmd*.report.txt
       source/tests/reports/phpcs*.report.txt
+      data/php/logs/error_log.txt
     prefix: 'styles_artifacts'
 
 # yamllint validates the github actions/testplan yaml files


### PR DESCRIPTION
This PR adds outputting the PHP error log also in the action itself and makes sure, the logs also end up in each steps artifact, not only in the logs artifact. Also a few minor fixes were included (Naming steps, using a comment as fist line in shell scripts, removing a set -x debugging statement).